### PR TITLE
Added autofocus and ref to input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
   "scripts": {

--- a/src/govuk/components/input/index.js
+++ b/src/govuk/components/input/index.js
@@ -12,7 +12,6 @@ function Input(props) {
     name,
     id,
     customRef,
-    autofocus,
     ...attributes
   } = props;
 
@@ -43,7 +42,6 @@ function Input(props) {
       {errorMessageComponent}
       <input
         id={id}
-        autoFocus={autofocus}
         className={`govuk-input ${className || ''} ${
           errorMessage ? ' govuk-input--error' : ''
         }`}

--- a/src/govuk/components/input/index.js
+++ b/src/govuk/components/input/index.js
@@ -11,6 +11,8 @@ function Input(props) {
     label,
     name,
     id,
+    customRef,
+    autofocus,
     ...attributes
   } = props;
 
@@ -41,10 +43,12 @@ function Input(props) {
       {errorMessageComponent}
       <input
         id={id}
+        autoFocus={autofocus}
         className={`govuk-input ${className || ''} ${
           errorMessage ? ' govuk-input--error' : ''
         }`}
         name={name || id}
+        ref={customRef}
         aria-describedby={describedByValue || null}
         {...attributes}
       />


### PR DESCRIPTION
We added an autofocus and ref to the input component.
The autofocus allows radio buttons to be clicked and focus on the input field.
The refs allow error links to be clicked and then focus on the related field.
These were needed for accessibility reasons.