### PR TITLE
Added a defaultValue attributte

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
   "scripts": {

--- a/src/govuk/components/date-input/index.js
+++ b/src/govuk/components/date-input/index.js
@@ -74,7 +74,7 @@ function DateInput(props) {
         type="text"
         inputMode="numeric"
         pattern={item.pattern ? item.pattern : '[0-9]*'}
-        defaultValue={defaultValue ? defaultValue[item.name] : ''}
+        defaultValue={defaultValue ? defaultValue[item.name] : null}
       />
     </div>
   ));

--- a/src/govuk/components/date-input/index.js
+++ b/src/govuk/components/date-input/index.js
@@ -12,6 +12,7 @@ function DateInput(props) {
     items,
     namePrefix,
     onChange,
+    defaultValue,
     ...attributes
   } = props;
 
@@ -73,6 +74,7 @@ function DateInput(props) {
         type="text"
         inputMode="numeric"
         pattern={item.pattern ? item.pattern : '[0-9]*'}
+        defaultValue={defaultValue ? defaultValue[item.name] : ''}
       />
     </div>
   ));


### PR DESCRIPTION
Had to add a `defaultValue` attribute and access the `defaultValue` object being passed through on the `Input` because the `Input` is a product of the mapping of `dateInputItems`. This is because otherwise when you go back to a page using the `DateInput` component, the values are not mapped correctly due to it using a list.