### PR TITLE
react-hook-form compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ## Releases
 
+### v1.4.0
+
+#### Features
+
+- `defaultValue` top level prop added to radios component to complement the `value` prop and facilitate compatibility with form libraries dealing with uncontrolled form inputs (Such as react-hook-form)
+
 ### v1.3.0
 
 #### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
   "scripts": {

--- a/src/govuk/components/radios/index.js
+++ b/src/govuk/components/radios/index.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { Boolean } from '../../../utils/Boolean';
 
 function Radios(props) {
-  const { value, items, ...restProps } = props;
+  const { value, defaultValue, items, ...restProps } = props;
 
   // Map React-like `value` top level prop to the child items' checked status
   const processedItems = items.map(item => ({
     ...item,
     ...(value && { checked: item.value === value }),
+    ...(defaultValue && { defaultChecked: item.value === defaultValue }),
   }));
 
   return <Boolean items={processedItems} {...restProps} controlType="radios" />;

--- a/src/govuk/components/radios/index.js
+++ b/src/govuk/components/radios/index.js
@@ -7,7 +7,7 @@ function Radios(props) {
   // Map React-like `value` top level prop to the child items' checked status
   const processedItems = items.map(item => ({
     ...item,
-    checked: item.value === value,
+    ...(value && { checked: item.value === value }),
   }));
 
   return <Boolean items={processedItems} {...restProps} controlType="radios" />;


### PR DESCRIPTION
Alter radios behaviour such that if a value prop isn't provided (uncontrolled input), then it does not set checked to false for all radios

Fixes #48