### PR TITLE
Fix bug when using controlled inputs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ## Releases
 
+### v1.4.1
+
+#### Fixes
+
+- Fix bug when using controlled inputs whereby Radios would switch from uncontrolled to controlled and throw a console warning. Caused by the new features added in v1.4.0
+
 ### v1.4.0
 
 #### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
   "scripts": {

--- a/src/govuk/components/radios/index.js
+++ b/src/govuk/components/radios/index.js
@@ -7,8 +7,10 @@ function Radios(props) {
   // Map React-like `value` top level prop to the child items' checked status
   const processedItems = items.map(item => ({
     ...item,
-    ...(value && { checked: item.value === value }),
-    ...(defaultValue && { defaultChecked: item.value === defaultValue }),
+    ...(value != null && { checked: item.value === value }),
+    ...(defaultValue != null && {
+      defaultChecked: item.value === defaultValue,
+    }),
   }));
 
   return <Boolean items={processedItems} {...restProps} controlType="radios" />;


### PR DESCRIPTION
Fix bug when using controlled inputs whereby Radios would switch from uncontrolled to controlled and throw a console warning. Caused by the new features added in v1.4.0