### PR TITLE
Rename Header serviceUrl and homepageUrl props to create html link or router link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 #### Breaking changes
 
-- Header links - `homepageUrl` and `serviceUrl` have become `homepageUrlHref` / `homepageUrlTo` and `serviceUrlHref` / `serviceUrlTo`, with the `To` variants being passed to a react-router `<Link>` the `Href` variants being a plain html `<a>` tag
-
 ---
 
 ## Releases
+
+### v2.0.0
+
+#### Breaking changes
+
+- Header links - `homepageUrl` and `serviceUrl` have become `homepageUrlHref` / `homepageUrlTo` and `serviceUrlHref` / `serviceUrlTo`, with the `To` variants being passed to a react-router `<Link>` the `Href` variants being a plain html `<a>` tag
 
 ### v1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Breaking changes
 
+- Header links - `homepageUrl` and `serviceUrl` have become `homepageUrlHref` / `homepageUrlTo` and `serviceUrlHref` / `serviceUrlTo`, with the `To` variants being passed to a react-router `<Link>` the `Href` variants being a plain html `<a>` tag
+
 ---
 
 ## Releases

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ View example app at https://surevine.github.io/govuk-react-jsx-examples/ (for wh
 ```
 $ npm install govuk-react-jsx
 ```
-(See [installation and usage](#installation--usage) for more details)
 
+(See [installation and usage](#installation--usage) for more details)
 
 ## Motivation
 
@@ -56,6 +56,7 @@ These components assume you:
 Exceptions to the conformance with govuk-frontend nunjucks params are as follows:
 
 - Links - Anywhere that accepts an `href` / `text` combo of params to create a hyperlink, will also accept a `to` prop instead of `href`, which will be used in a react-router `<Link>` element.
+- Header links - `homepageUrl` and `serviceUrl` become `homepageUrlHref` / `homepageUrlTo` and `serviceUrlHref` / `serviceUrlTo`, with the `To` variants being passed to a react-router `<Link>` the `Href` variants being a plain html `<a>` tag
 - Anywhere that accepts an `html` or `text` param in Nunjucks will instead accept a `children` prop which should be passed either a string, or JSX. Params such as `summaryText` or `summaryHtml` become `summaryChildren`
 - `classes` becomes `className`
 - `describedBy` becomes `aria-describedby`
@@ -80,7 +81,7 @@ NB: `govuk-react-jsx` has a number package dependencies, including:
 
 A full list can be found in the `dependencies` section of [`/scripts/package.json`](https://github.com/surevine/govuk-react-jsx/blob/master/scripts/package.json)
 
-An example of setting up create-react-app to use govuk-react-jsx can be viewed in [this commit over on govuk-react-jsx-examples](https://github.com/surevine/govuk-react-jsx-examples/commit/2bcdfb4ccfd6597eb9b5a410ae76322b64b9dcfa). 
+An example of setting up create-react-app to use govuk-react-jsx can be viewed in [this commit over on govuk-react-jsx-examples](https://github.com/surevine/govuk-react-jsx-examples/commit/2bcdfb4ccfd6597eb9b5a410ae76322b64b9dcfa).
 
 ### Using Styles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-react-jsx",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
   "scripts": {

--- a/src/govuk/components/header/index.js
+++ b/src/govuk/components/header/index.js
@@ -7,12 +7,14 @@ function Header(props) {
   const {
     className,
     containerClassName,
-    homepageUrl,
+    homepageUrlHref,
+    homepageUrlTo,
     navigation,
     navigationClassName,
     productName,
     serviceName,
-    serviceUrl,
+    serviceUrlHref,
+    serviceUrlTo,
     // eslint-disable-next-line no-unused-vars
     assetsPath, // We don't want this, but just in case someone passes it, we don't want it to arrive as an attribute on the header
     ...attributes
@@ -36,12 +38,13 @@ function Header(props) {
     navigationComponent = (
       <div className="govuk-header__content">
         {serviceName ? (
-          <a
-            href={serviceUrl}
+          <Link
+            href={serviceUrlHref}
+            to={serviceUrlTo}
             className="govuk-header__link govuk-header__link--service-name"
           >
             {serviceName}
-          </a>
+          </Link>
         ) : null}
 
         {navigation ? (
@@ -107,7 +110,8 @@ function Header(props) {
       <div className={`govuk-header__container ${containerClassName}`}>
         <div className="govuk-header__logo">
           <Link
-            to={homepageUrl}
+            to={homepageUrlTo}
+            href={homepageUrlHref}
             className="govuk-header__link govuk-header__link--homepage"
           >
             <span className="govuk-header__logotype">
@@ -145,7 +149,7 @@ function Header(props) {
 }
 
 Header.defaultProps = {
-  homepageUrl: '/',
+  homepageUrlHref: '/',
   containerClassName: 'govuk-width-container',
 };
 

--- a/tests/utils/govuk-frontend-diff.js
+++ b/tests/utils/govuk-frontend-diff.js
@@ -28,7 +28,6 @@ const htmlDiffer = new HtmlDiffer({
     'style', // Ignored because React outputs inline styles in a slightly different format. This only affects one edge case and so can be relatively safely ignored
     'disabled', // Because React sets disabled as an empty attribute but the nunjucks does not
     'src', // Because paths to images aren't something that need to be the same between react and nunjucks
-    'href', // Temporarily ignored because passing a string through the `to` prop in the <Header> component causes erroneous diffs relative to the nunjucks
   ],
   ignoreSelfClosingSlash: true,
 });

--- a/utils/processExampleData.js
+++ b/utils/processExampleData.js
@@ -20,6 +20,8 @@ const propReplacements = {
   titleText: 'titleChildren',
   titleHtml: 'titleChildren',
   inputmode: 'inputMode',
+  serviceUrl: 'serviceUrlHref',
+  homepageUrl: 'homepageUrlHref',
 };
 
 export default function processExampleData(data, componentName) {


### PR DESCRIPTION
`homepageUrl` and `serviceUrl` have become `homepageUrlHref` / `homepageUrlTo` and `serviceUrlHref` / `serviceUrlTo`, with the `To` variants being passed to a react-router `<Link>` the `Href` variants being a plain html `<a>` tag

Fixes #21 