### PR TITLE
chore/build-as-ESM

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@ storybook-static
 dist
 build-temp
 node_modules
+module
 storybook-static
 !.storybook

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ storybook-static
 dist
 build-temp
 .DS_Store
+.idea
+module

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 scripts
 src/*/**
 tests
-utils
+/utils
 .editorconfig
 .eslintignore
 .eslintrc

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+scripts
+src/*/**
+tests
+utils
+.editorconfig
+.eslintignore
+.eslintrc
+.storybook
+.idea

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,12 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": [
+    [
+      "@babel/preset-env", {
+        "modules": false
+      }
+    ],
+    "@babel/preset-react"
+  ],
   "plugins": [
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-transform-runtime"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.3",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
   "main": "src/govuk/index.js",
+  "module": "module/index.js",
   "scripts": {
     "test": "jest --notify --verbose",
     "storybook": "start-storybook -p 6006",
@@ -14,6 +15,7 @@
     "start": "npm run storybook",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "build-module": "BABEL_ENV=module babel --ignore **/**/*.story.js,**/**/examples.js ./src --out-dir ./module --source-maps inline",
     "deploy-demo": "npm run build-storybook && gh-pages -d storybook-static",
     "build": "./scripts/build.sh",
     "publish-local": "./scripts/publish-local.sh",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "govuk-react-jsx",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "React component ports of govuk-frontend nunjucks macros. Directly consuming govuk-frontend CSS & JS.",
-  "main": "src/govuk/index.js",
-  "module": "module/index.js",
+  "main": "dist/govuk/index.js",
+  "module": "module/govuk/index.js",
   "scripts": {
     "test": "jest --notify --verbose",
     "storybook": "start-storybook -p 6006",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,7 @@ copy govuk/index.js govuk/template/index.js govuk/components/**/index.js utils/*
 cd ..
 babel --config-file ./scripts/babel.config.json build-temp -d dist
 rm -rf build-temp
+npm run build-module
 
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
 sed "s/PACKAGE_VERSION/${PACKAGE_VERSION}/g" scripts/package.json > dist/package.json

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ./scripts/build.sh
-npm publish dist
+npm publish

--- a/src/govuk/components/back-link/index.js
+++ b/src/govuk/components/back-link/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 function BackLink(props) {
   const { children, href, to, className, ...attributes } = props;

--- a/src/govuk/components/breadcrumbs/index.js
+++ b/src/govuk/components/breadcrumbs/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 function Breadcrumbs(props) {
   const { items, className, collapseOnMobile, ...attributes } = props;

--- a/src/govuk/components/button/index.js
+++ b/src/govuk/components/button/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 const Button = React.forwardRef((props, ref) => {
   const {

--- a/src/govuk/components/character-count/index.js
+++ b/src/govuk/components/character-count/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
-import { Textarea, Hint } from '../..';
+import { Textarea } from '../textarea';
+import { Hint } from '../hint';
 
 const CharacterCount = React.forwardRef((props, ref) => {
   const {

--- a/src/govuk/components/date-input/index.js
+++ b/src/govuk/components/date-input/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Hint, ErrorMessage, Fieldset, Input } from '../..';
+import { Fieldset } from '../fieldset';
+import { Input } from '../input';
+import { Hint } from '../Hint';
+import { ErrorMessage } from '../error-message';
 
 function DateInput(props) {
   const {

--- a/src/govuk/components/footer/index.js
+++ b/src/govuk/components/footer/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 function Footer(props) {
   const {

--- a/src/govuk/components/header/index.js
+++ b/src/govuk/components/header/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 
 import logo from 'govuk-frontend/govuk/assets/images/govuk-logotype-crown.png';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 function Header(props) {
   const {

--- a/src/govuk/components/input/index.js
+++ b/src/govuk/components/input/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Label, Hint, ErrorMessage } from '../..';
+import { Label } from '../label';
+import { Hint } from '../Hint';
+import { ErrorMessage } from '../error-message';
 
 const Input = React.forwardRef((props, ref) => {
   const {

--- a/src/govuk/components/phase-banner/index.js
+++ b/src/govuk/components/phase-banner/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tag } from '../..';
+import { Tag } from '../tag';
 
 function PhaseBanner(props) {
   const { className, tag, children, ...attributes } = props;

--- a/src/govuk/components/select/index.js
+++ b/src/govuk/components/select/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Label, Hint, ErrorMessage } from '../..';
+import { Label } from '../label';
+import { Hint } from '../Hint';
+import { ErrorMessage } from '../error-message';
 
 const Select = React.forwardRef((props, ref) => {
   const {

--- a/src/govuk/components/summary-list/index.js
+++ b/src/govuk/components/summary-list/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from '../../../utils/Link';
+import { Link } from './../../../utils/Link';
 
 function ActionLink(props) {
   const {

--- a/src/govuk/components/textarea/index.js
+++ b/src/govuk/components/textarea/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Label, Hint, ErrorMessage } from '../..';
+import { Label } from '../label';
+import { Hint } from '../Hint';
+import { ErrorMessage } from '../error-message';
 
 const Textarea = React.forwardRef((props, ref) => {
   const {


### PR DESCRIPTION
Hi! 

xgov-form-builder is a project we're working on. Essentially it's a react app "designer", which spits out a JSON which allows the "runner" to play the config as a live service. The designer was not as actively worked on, but we're on it now 👷🏻‍♀️. We'd like to consume this package but we had some issues with importing and our build/test process.

# Description

Currently, the build process is building in cjs (node-compatible) format. Since its react -- web, ESM is fine (import/export syntax). For any compilers that are ESM aware, it will use the module entry-point instead. 

- compile for ESM
  - compiling into module
  - script is in package.json
  - I'm ignoring any storybook stuff. We just want to consume the components!
- added entrypoint for ESM in package.json ("module" key)
- removing circular dependencies
  - by doing import/require '../..' you end up importing everything in the index. This way you end up with circular deps. I'm doing exact imports instead
- publish script
  - I've changed the publish script to publish root, but added npm ignore to everything that's not dist or module
    - now that root is published, you can forgo doing `cp` of readme etc. I've left it in just in case you need them here though.
  - changed entry-point of "main" to `dist/govuk/index.js`
- version bump to 4.0.4 :) 

We have tested this by installing on our own fork. looks good to us!


