### PR TITLE
Fixing skiplink when called from template not passing text correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### Fixes
 
+- Fix Template not passing text correctly to SkipLink component (https://github.com/surevine/govuk-react-jsx/pull/116)
+  - Fixes https://github.com/surevine/govuk-react-jsx/issues/115
+
 #### Features
 
 #### Breaking changes

--- a/src/govuk/template/index.js
+++ b/src/govuk/template/index.js
@@ -14,7 +14,7 @@ function Template(props) {
   const {
     children,
     title,
-    skiplink,
+    skipLink,
     header,
     footer,
     beforeContent,
@@ -60,7 +60,7 @@ function Template(props) {
         <meta property="og:image" content={govukOpenGraphImage} />
       </Helmet>
 
-      <SkipLink {...skiplink} />
+      <SkipLink {...skipLink} />
 
       <Header {...header} />
 
@@ -85,7 +85,7 @@ Template.defaultProps = {
   title: 'GOV.UK - The best place to find government services and information',
   skipLink: {
     href: '#main-content',
-    text: 'Skip to main content',
+    children: 'Skip to main content',
   },
   header: {},
   footer: {},


### PR DESCRIPTION
Fixes #115 